### PR TITLE
fix be disabled problem with opening the menu

### DIFF
--- a/VRCPlayersOnlyMirrorSDK2/Assets/VRCPlayersOnlyMirror/Shaders/TransparentBackground.shader
+++ b/VRCPlayersOnlyMirrorSDK2/Assets/VRCPlayersOnlyMirror/Shaders/TransparentBackground.shader
@@ -35,7 +35,7 @@ SubShader {
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 o.vertex = UnityObjectToClipPos(v.vertex);
-                if (_MirrorOnly == 1 & (unity_CameraProjection[2][0] == 0.f || unity_CameraProjection[2][1] == 0.f)){
+                if (_MirrorOnly == 1 & !(0 < dot(cross(UNITY_MATRIX_V[0], UNITY_MATRIX_V[1]), UNITY_MATRIX_V[2]))){
                     o.vertex = -1;
                 }
                 UNITY_TRANSFER_FOG(o,o.vertex);

--- a/VRCPlayersOnlyMirrorSDK3/Assets/VRCPlayersOnlyMirror/Shaders/TransparentBackground.shader
+++ b/VRCPlayersOnlyMirrorSDK3/Assets/VRCPlayersOnlyMirror/Shaders/TransparentBackground.shader
@@ -35,7 +35,7 @@ SubShader {
                 UNITY_SETUP_INSTANCE_ID(v);
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 o.vertex = UnityObjectToClipPos(v.vertex);
-				if (_MirrorOnly == 1 & (unity_CameraProjection[2][0] == 0.f || unity_CameraProjection[2][1] == 0.f)){
+				if (_MirrorOnly == 1 & !(0 < dot(cross(UNITY_MATRIX_V[0], UNITY_MATRIX_V[1]), UNITY_MATRIX_V[2]))){
 					o.vertex = -1;
 				}
                 UNITY_TRANSFER_FOG(o,o.vertex);


### PR DESCRIPTION
Fix the following issue (by @NazimiShatoo)
- Opening the menu will cause the mirror transparency to temporarily be disabled